### PR TITLE
Install python on ubuntu 16.04 images

### DIFF
--- a/scripts/image_create_ubuntu-16.04.sh
+++ b/scripts/image_create_ubuntu-16.04.sh
@@ -3,7 +3,7 @@ DIB_RELEASE="xenial"
 IMAGE_NAME="Ubuntu-16.04"
 CLOUD_INIT_DEFAULT_USER_NAME="cloud-user"
 ELEMENTS="vm cloud-init-cfg ubuntu"
-PACKAGES="vim,ntp"
+PACKAGES="vim,ntp,python"
 
 export DIB_RELEASE
 export CLOUD_INIT_DEFAULT_USER_NAME


### PR DESCRIPTION
If we don't install python the build fails.

Error 1:

/usr/local/bin/dib-run-parts: line 106: python: command not found

(this was fixed by updating dib-run-parts to the latest version which
does not use python to calculate duration)

But after fixing that one saw this during the install stage - this was
fixed by installing python

dib-run-parts Mon Aug 28 07:29:03 UTC 2017 Running
/tmp/in_target.d/install.d/00-baseli
ne-environment
/usr/bin/env: ‘python’: No such file or directory
bin/pkg-map error.