### PR TITLE
Add scripts for creating GPU Images

### DIFF
--- a/scripts/image_create_centos7-gpu.sh
+++ b/scripts/image_create_centos7-gpu.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -lv
+DISTRO_NAME="centos7"
+IMAGE_NAME="CentOS-7-GPU"
+CLOUD_INIT_DEFAULT_USER_NAME="cloud-user"
+ELEMENTS="vm cloud-init-cfg centos7 nvidia-cuda"
+PACKAGES="vim,ntp,deltarpm,cuda"
+IMAGE_VISIBILITY="private"
+
+export CLOUD_INIT_DEFAULT_USER_NAME
+
+source $(dirname $0)/image_create.sh
+

--- a/scripts/image_create_ubuntu-16.04-gpu.sh
+++ b/scripts/image_create_ubuntu-16.04-gpu.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -lv
+DIB_RELEASE="xenial"
+IMAGE_NAME="Ubuntu-16.04-GPU"
+CLOUD_INIT_DEFAULT_USER_NAME="cloud-user"
+ELEMENTS="vm cloud-init-cfg ubuntu nvidia-cuda"
+PACKAGES="vim,ntp,python,linux-headers-generic,cuda"
+IMAGE_VISIBILITY="private"
+
+export DIB_RELEASE
+export CLOUD_INIT_DEFAULT_USER_NAME
+
+source $(dirname $0)/image_create.sh
+


### PR DESCRIPTION
Add 2 new scripts to create and push GPU images to e/cPouta
environments. Added a bash -lv option to the scripts so we get more
verbose output when the script runs and writes to the logfile.