### PR TITLE
Make our Cuda images public

### DIFF
--- a/scripts/image_create_centos7-cuda.sh
+++ b/scripts/image_create_centos7-cuda.sh
@@ -4,7 +4,7 @@ IMAGE_NAME="CentOS-7-Cuda"
 CLOUD_INIT_DEFAULT_USER_NAME="cloud-user"
 ELEMENTS="vm cloud-init-cfg centos7 nvidia-cuda"
 PACKAGES="vim,ntp,deltarpm,cuda"
-IMAGE_VISIBILITY="private"
+IMAGE_VISIBILITY="public"
 
 export CLOUD_INIT_DEFAULT_USER_NAME
 

--- a/scripts/image_create_ubuntu-16.04-cuda.sh
+++ b/scripts/image_create_ubuntu-16.04-cuda.sh
@@ -4,7 +4,7 @@ IMAGE_NAME="Ubuntu-16.04-Cuda"
 CLOUD_INIT_DEFAULT_USER_NAME="cloud-user"
 ELEMENTS="vm cloud-init-cfg ubuntu nvidia-cuda"
 PACKAGES="vim,ntp,python,linux-headers-generic,cuda"
-IMAGE_VISIBILITY="private"
+IMAGE_VISIBILITY="public"
 
 export DIB_RELEASE
 export CLOUD_INIT_DEFAULT_USER_NAME


### PR DESCRIPTION
Testing is now done and we are releasing the GPGPU nodes 22.9.2107. For
this we now make the scripts build the images and make them public by
default.