### PR TITLE
Fix removing of running vm's during image deploy

### DIFF
--- a/scripts/image_create.sh
+++ b/scripts/image_create.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -lv
 # Create cloud image, push it to OpenStack and create test instance
 
 echo "=== "$(date)

--- a/scripts/image_functions.sh
+++ b/scripts/image_functions.sh
@@ -1,19 +1,23 @@
-#!/bin/bash
+#!/bin/bash -lv
 export PYTHONIOENCODING
 
 function cleanup() {
-	find . -name "${IMAGE_NAME}*.d" -type d -exec rm -rf {} + 2>/dev/null
-    find . -name "${IMAGE_NAME}*.qcow2" -type f -exec rm -f {} + 2>/dev/null
-	# delete any orphaned temporary images using image_id
-	for id in $(glance image-list | grep "$TMP_IMAGE_NAME" | awk '{print $2}')
-	do
-		glance image-delete "$id" &>/dev/null || true
-	done
-	# delete any orphaned test instance using instance_id
-	for id in $(nova list | grep "$TEST_INSTANCE_NAME" | awk '{print $2}')
-	do
-		nova delete "$id" &>/dev/null || true
-	done
+    echo "Deleting ${IMAGE_NAME}*.d folders"
+    find . -maxdepth 5 -name "${IMAGE_NAME}*.d" -type d -exec rm -rf {} +
+    echo "Deleting ${IMAGE_NAME}*.qcow2 files"
+    find . -maxdepth 5 -name "${IMAGE_NAME}*.qcow2" -type f -exec rm -f {} +
+    # delete any orphaned temporary images using image_id
+    echo "Deleting old images from OS"
+    for id in $(glance image-list | grep "$TMP_IMAGE_NAME" | awk '{print $2}')
+    do
+        glance image-delete "$id" &>/dev/null || true
+    done
+    # delete any orphaned test instance using instance_id
+    echo "Deleting orphaned test instance using instance_id"
+    for id in $(nova list | grep "$TEST_INSTANCE_NAME" | awk '{print $2}')
+    do
+        nova delete "$id" &>/dev/null || true
+    done
 }
 
 function image_create() {


### PR DESCRIPTION
* Add a maxdepth of 5 for find files and folders to the cleanup function.
  This was to avoid the set -eu that is set before all our image functions
  are called, and if we get an error of exit status 1 the rest of the cmds
  in the function don't run. This was due to root:root owning the folders
  in the $HOME/temp/image*/mnt/ in the imgbuild home directory. This happens
  during the image build process and causes the find commands to fail
  as permission denied errors are returned

* Add the -lv to the image_create and image_function scripts to get more detail
  in our logs to help with debugging.