### PR TITLE
Add Ubuntu 18.04 images straight from upstream

### DIFF
--- a/scripts/crontab
+++ b/scripts/crontab
@@ -15,6 +15,7 @@ SHELL=/bin/bash
 0 8 1,16 * * source $HOME/bin/openrc_cpouta_prod_v3.sh; $HOME/diskimage-builder-scripts.cpouta/scripts/image_create_ubuntu-16.04-cuda.sh >> $HOME/log/c/ubuntu-16.04-cuda.log 2>&1
 
 0 9 1,16 * * source $HOME/bin/openrc_cpouta_prod_v3.sh; $HOME/diskimage-builder-scripts.cpouta/scripts/image_create_fedora_atomic_dl.sh >> $HOME/log/c/fedora-atomic.log 2>&1
+0 10 1,16 * * source $HOME/bin/openrc_cpouta_prod_v3.sh; $HOME/diskimage-builder-scripts.cpouta/scripts/image_create_ubuntu-18.04.sh >> $HOME/log/c/ubuntu-18.04.log 2>&1
 
 ######## ePouta production
 # m h  dom mon dow   command
@@ -29,3 +30,4 @@ SHELL=/bin/bash
 
 0 7 2,17 * * source $HOME/bin/openrc_epouta_prod_v3.sh; $HOME/diskimage-builder-scripts.epouta/scripts/image_create_centos7-cuda.sh >> $HOME/log/e/centos7-cuda.log 2>&1
 0 8 2,17 * * source $HOME/bin/openrc_epouta_prod_v3.sh; $HOME/diskimage-builder-scripts.epouta/scripts/image_create_ubuntu-16.04-cuda.sh >> $HOME/log/e/ubuntu-16.04-cuda.log 2>&1
+0 9 2,17 * * source $HOME/bin/openrc_epouta_prod_v3.sh; $HOME/diskimage-builder-scripts.epouta/scripts/image_create_ubuntu-18.04.sh >> $HOME/log/e/ubuntu-18.04.log 2>&1

--- a/scripts/image_create_ubuntu-18.04.sh
+++ b/scripts/image_create_ubuntu-18.04.sh
@@ -1,0 +1,8 @@
+#!/bin/bash --login
+UBUNTU_URL="http://cloud-images.ubuntu.com/bionic/current/"
+DOWNLOAD_URL="$UBUNTU_URL/bionic-server-cloudimg-amd64.img"
+IMAGE_NAME="Ubuntu-18.04"
+OS_DISTRO_PROPERTY="ubuntu"
+IMAGE_VISIBILITY="public"
+
+source $(dirname $0)/image_dl_test_deploy.sh "$DOWNLOAD_URL"

--- a/scripts/image_dl_test_deploy.sh
+++ b/scripts/image_dl_test_deploy.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 # Download cloud image, push it to glance and create test instance
 
+if [[ $(dirname $0) == *epouta* ]]; then
+source $(dirname $0)/image_epouta_constants.sh
+else
 source $(dirname $0)/image_cpouta_constants.sh
+fi
 source $(dirname $0)/image_functions.sh
 
 set -eu


### PR DESCRIPTION
 - #CCCP-1853 some prestudy was done - making our diskimage-builder
   build 18.04 was not easy
 - Using the method in this was easy:
  - download the latest bionic cloud image (they are built daily by
    canonical)
  - run our usual stuff (upload temp image, spawn an instance, etc)
 - The upstream Ubuntu cloud-image has cloud-init installed
  - Default user name is ubuntu, not cloud-user