### PR TITLE
Disable CentOS8 updating until upstream is good

### DIFF
--- a/scripts/crontab
+++ b/scripts/crontab
@@ -13,7 +13,7 @@ SHELL=/bin/bash
 
 0 7 1,16 * * source $HOME/bin/openrc_cpouta_prod_v3.sh; $HOME/diskimage-builder-scripts.cpouta/scripts/image_create_ubuntu-18.04.sh >> $HOME/log/c/ubuntu-18.04.log 2>&1
 0 8 1,16 * * source $HOME/bin/openrc_cpouta_prod_v3.sh; $HOME/diskimage-builder-scripts.cpouta/scripts/image_create_fedora_atomic_dl.sh >> $HOME/log/c/fedora-atomic.log 2>&1
-0 9 1,16 * * source $HOME/bin/openrc_cpouta_prod_v3.sh; $HOME/diskimage-builder-scripts.cpouta/scripts/image_create_centos8.sh >> $HOME/log/c/centos8.log 2>&1
+#0 9 1,16 * * source $HOME/bin/openrc_cpouta_prod_v3.sh; $HOME/diskimage-builder-scripts.cpouta/scripts/image_create_centos8.sh >> $HOME/log/c/centos8.log 2>&1
 
 ######## ePouta production
 # m h  dom mon dow   command
@@ -26,7 +26,7 @@ SHELL=/bin/bash
 0 6 2,17 * * source $HOME/bin/openrc_epouta_prod_v3.sh; $HOME/diskimage-builder-scripts.epouta/scripts/image_create_ubuntu-16.04-cuda.sh >> $HOME/log/e/ubuntu-16.04-cuda.log 2>&1
 
 0 7 2,17 * * source $HOME/bin/openrc_epouta_prod_v3.sh; $HOME/diskimage-builder-scripts.epouta/scripts/image_create_ubuntu-18.04.sh >> $HOME/log/e/ubuntu-18.04.log 2>&1
-0 8 2,17 * * source $HOME/bin/openrc_epouta_prod_v3.sh; $HOME/diskimage-builder-scripts.epouta/scripts/image_create_centos8.sh >> $HOME/log/e/centos8.log 2>&1
+#0 8 2,17 * * source $HOME/bin/openrc_epouta_prod_v3.sh; $HOME/diskimage-builder-scripts.epouta/scripts/image_create_centos8.sh >> $HOME/log/e/centos8.log 2>&1
 
 ######## cPouta devel
 # m h  dom mon dow   command
@@ -40,4 +40,4 @@ SHELL=/bin/bash
 
 0 15 * * * source $HOME/bin/openrc_cpouta_devel_v3.sh; $HOME/diskimage-builder-scripts.cpouta-devel/scripts/image_create_ubuntu-18.04.sh >> $HOME/log/c-devel/ubuntu-18.04.log 2>&1
 0 16 * * * source $HOME/bin/openrc_cpouta_devel_v3.sh; $HOME/diskimage-builder-scripts.cpouta-devel/scripts/image_create_fedora_atomic_dl.sh >> $HOME/log/c-devel/fedora-atomic.log 2>&1
-0 17 * * * source $HOME/bin/openrc_cpouta_devel_v3.sh; $HOME/diskimage-builder-scripts.cpouta-devel/scripts/image_create_centos8.sh >> $HOME/log/c-devel/centos8.log 2>&1
+#0 17 * * * source $HOME/bin/openrc_cpouta_devel_v3.sh; $HOME/diskimage-builder-scripts.cpouta-devel/scripts/image_create_centos8.sh >> $HOME/log/c-devel/centos8.log 2>&1


### PR DESCRIPTION
Issues:
 - centos user
 - build leftovers in /root/ and /etc/resolv.conf and /var/log/anaconda