### PR TITLE
Let the nvidia-cuda element install cuda

### DIFF
--- a/scripts/image_create_centos7-cuda.sh
+++ b/scripts/image_create_centos7-cuda.sh
@@ -3,7 +3,7 @@ DISTRO_NAME="centos7"
 IMAGE_NAME="CentOS-7-Cuda"
 CLOUD_INIT_DEFAULT_USER_NAME="cloud-user"
 ELEMENTS="vm cloud-init-cfg centos7 nvidia-cuda"
-PACKAGES="vim,ntp,deltarpm,cuda"
+PACKAGES="vim,ntp,deltarpm"
 IMAGE_VISIBILITY="public"
 CLOUD_INIT_CFG_AUTOUPDATE="false"
 


### PR DESCRIPTION
Do not install cuda as part of packages.

According to:

https://github.com/CSCfi/diskimage-builder/blob/csc/lib/img-functions#L143

the packages are installed prior to the elements getting
processed. If we take a head start installing cuda, this can fudge
up the whole kernel/headers installation part. So omit this cuda package
installation altogether, and just let the nvidia-cuda element install
cuda at a more suitable time.