### PR TITLE
Remove CentOS-8 script + fix image description

### DIFF
--- a/scripts/image_create_centos8.sh
+++ b/scripts/image_create_centos8.sh
@@ -1,8 +1,0 @@
-#!/bin/bash --login
-DISTRO_URL="https://cloud.centos.org/centos/8/x86_64/images/"
-DOWNLOAD_URL="$DISTRO_URL/CentOS-8-GenericCloud-8.1.1911-20200113.3.x86_64.qcow2"
-IMAGE_NAME="CentOS-8"
-OS_DISTRO_PROPERTY="centos"
-IMAGE_VISIBILITY="public"
-
-source $(dirname $0)/image_dl_test_deploy.sh "$DOWNLOAD_URL"

--- a/scripts/image_functions.sh
+++ b/scripts/image_functions.sh
@@ -78,8 +78,8 @@ function image_deploy() {
       DESCRIPTION="All packages of this image were updated on $(date +%F). To find out which user to login with: ssh in as root."
     fi
     glance image-update --name "$IMAGE_NAME" \
-      --property description="$DESCRIPTION" \  
-      --visibility "$IMAGE_VISIBILITY" \
+        --property description="$DESCRIPTION" \
+        --visibility "$IMAGE_VISIBILITY" \
         $(glance image-list | grep "$TMP_IMAGE_NAME" | cut -d '|' -f2)
 }
 

--- a/scripts/image_functions.sh
+++ b/scripts/image_functions.sh
@@ -73,9 +73,13 @@ function image_deploy() {
     fi
     # rename new image
     echo "Renaming $TMP_IMAGE_NAME to $IMAGE_NAME"
+    DESCRIPTION=""
+    if [[ "$IMAGE_NAME" == "CentOS-7"* ]]; then
+      DESCRIPTION="All packages of this image were updated on $(date +%F). To find out which user to login with: ssh in as root."
+    fi
     glance image-update --name "$IMAGE_NAME" \
-        --property description="All packages of this image were updated on $(date +%F). To find out which user to login with: ssh in as root." \
-        --visibility "$IMAGE_VISIBILITY" \
+      --property description="$DESCRIPTION" \  
+      --visibility "$IMAGE_VISIBILITY" \
         $(glance image-list | grep "$TMP_IMAGE_NAME" | cut -d '|' -f2)
 }
 

--- a/scripts/image_functions.sh
+++ b/scripts/image_functions.sh
@@ -75,8 +75,9 @@ function image_deploy() {
     echo "Renaming $TMP_IMAGE_NAME to $IMAGE_NAME"
     DESCRIPTION=""
     if [[ "$IMAGE_NAME" == "CentOS-7"* ]]; then
-      DESCRIPTION="All packages of this image were updated on $(date +%F). To find out which user to login with: ssh in as root."
+      DESCRIPTION="All packages of this image were updated on $(date +%F). "
     fi
+    DESCRIPTION="${DESCRIPTION}To find out which user to login with: ssh in as root."
     glance image-update --name "$IMAGE_NAME" \
         --property description="$DESCRIPTION" \
         --visibility "$IMAGE_VISIBILITY" \


### PR DESCRIPTION
CentOS-8 script is not used anymore and should thus be removed. In addition, the description of the image saying that all the packages have been updated on the date of the build is true only for CentOS-7 images but not for the ones fetched upstream