### PR TITLE
Remove CentOS7 CentOS7-cuda image build

### DIFF
--- a/check_image_building/check_image_building_cpouta_devel.json
+++ b/check_image_building/check_image_building_cpouta_devel.json
@@ -8,7 +8,6 @@
         "ubuntu-20.04",
         "ubuntu-22.04",
         "ubuntu-24.04",
-        "centos8_stream",
         "centos9_stream",
         "alma8",
         "alma9"

--- a/check_image_building/check_image_building_cpouta_devel.json
+++ b/check_image_building/check_image_building_cpouta_devel.json
@@ -1,17 +1,15 @@
 {
-    "base_path" : "/home/imgbuild/log",
-    "environments" : [
-        {
-            "name" : "c-devel",
-            "images" : [
-                "centos7",
-                "centos7-cuda",
-                "ubuntu-18.04",
-                "ubuntu-20.04",
-                "ubuntu-22.04",
-                "ubuntu-24.04",
-                "centos8_stream"
-            ]
-        }
-    ]
+  "base_path": "/home/imgbuild/log",
+  "environments": [
+    {
+      "name": "c-devel",
+      "images": [
+        "ubuntu-18.04",
+        "ubuntu-20.04",
+        "ubuntu-22.04",
+        "ubuntu-24.04",
+        "centos8_stream"
+      ]
+    }
+  ]
 }

--- a/check_image_building/check_image_building_cpouta_devel.json
+++ b/check_image_building/check_image_building_cpouta_devel.json
@@ -8,7 +8,10 @@
         "ubuntu-20.04",
         "ubuntu-22.04",
         "ubuntu-24.04",
-        "centos8_stream"
+        "centos8_stream",
+        "centos9_stream",
+        "alma8",
+        "alma9"
       ]
     }
   ]

--- a/check_image_building/check_image_building_cpouta_production.cfg
+++ b/check_image_building/check_image_building_cpouta_production.cfg
@@ -1,0 +1,1 @@
+command[check_image_building_cpouta_production]=/usr/local/nagios/libexec/nrpe_local/check_image_building.py -c /etc/nrpe.d/check_image_building_cpouta_production.json

--- a/check_image_building/check_image_building_cpouta_production.json
+++ b/check_image_building/check_image_building_cpouta_production.json
@@ -1,18 +1,17 @@
 {
-    "base_path" : "/home/imgbuild/log",
-    "environments" : [
-        {
-            "name" : "c",
-            "images" : [
-                "ubuntu-18.04",
-                "ubuntu-20.04",
-                "ubuntu-22.04",
-                "ubuntu-24.04",
-                "centos8_stream",
-                "centos9_stream",
-                "alma8",
-                "alma9"
-            ]
-        }
-    ]
+  "base_path": "/home/imgbuild/log",
+  "environments": [
+    {
+      "name": "c",
+      "images": [
+        "ubuntu-18.04",
+        "ubuntu-20.04",
+        "ubuntu-22.04",
+        "ubuntu-24.04",
+        "centos9_stream",
+        "alma8",
+        "alma9"
+      ]
+    }
+  ]
 }

--- a/check_image_building/check_image_building_cpouta_production.json
+++ b/check_image_building/check_image_building_cpouta_production.json
@@ -1,0 +1,18 @@
+{
+    "base_path" : "/home/imgbuild/log",
+    "environments" : [
+        {
+            "name" : "c",
+            "images" : [
+                "ubuntu-18.04",
+                "ubuntu-20.04",
+                "ubuntu-22.04",
+                "ubuntu-24.04",
+                "centos8_stream",
+                "centos9_stream",
+                "alma8",
+                "alma9"
+            ]
+        }
+    ]
+}

--- a/check_image_building/check_image_building_epouta_devel.cfg
+++ b/check_image_building/check_image_building_epouta_devel.cfg
@@ -1,0 +1,1 @@
+command[check_image_building_epouta_devel]=/usr/local/nagios/libexec/nrpe_local/check_image_building.py -c /etc/nrpe.d/check_image_building_epouta_devel.json

--- a/check_image_building/check_image_building_epouta_devel.json
+++ b/check_image_building/check_image_building_epouta_devel.json
@@ -1,0 +1,18 @@
+{
+    "base_path" : "/home/imgbuild/log",
+    "environments" : [
+        {
+            "name" : "e-devel",
+            "images" : [
+                "ubuntu-18.04",
+                "ubuntu-20.04",
+                "ubuntu-22.04",
+                "ubuntu-24.04",
+                "centos8_stream",
+                "centos9_stream",
+                "alma8",
+                "alma9"
+            ]
+        }
+    ]
+}

--- a/check_image_building/check_image_building_epouta_devel.json
+++ b/check_image_building/check_image_building_epouta_devel.json
@@ -1,18 +1,17 @@
 {
-    "base_path" : "/home/imgbuild/log",
-    "environments" : [
-        {
-            "name" : "e-devel",
-            "images" : [
-                "ubuntu-18.04",
-                "ubuntu-20.04",
-                "ubuntu-22.04",
-                "ubuntu-24.04",
-                "centos8_stream",
-                "centos9_stream",
-                "alma8",
-                "alma9"
-            ]
-        }
-    ]
+  "base_path": "/home/imgbuild/log",
+  "environments": [
+    {
+      "name": "e-devel",
+      "images": [
+        "ubuntu-18.04",
+        "ubuntu-20.04",
+        "ubuntu-22.04",
+        "ubuntu-24.04",
+        "centos9_stream",
+        "alma8",
+        "alma9"
+      ]
+    }
+  ]
 }

--- a/check_image_building/check_image_building_epouta_production.cfg
+++ b/check_image_building/check_image_building_epouta_production.cfg
@@ -1,0 +1,1 @@
+command[check_image_building_epouta_production]=/usr/local/nagios/libexec/nrpe_local/check_image_building.py -c /etc/nrpe.d/check_image_building_epouta_production.json

--- a/check_image_building/check_image_building_epouta_production.json
+++ b/check_image_building/check_image_building_epouta_production.json
@@ -1,18 +1,17 @@
 {
-    "base_path" : "/home/imgbuild/log",
-    "environments" : [
-        {
-            "name" : "e",
-            "images" : [
-                "ubuntu-18.04",
-                "ubuntu-20.04",
-                "ubuntu-22.04",
-                "ubuntu-24.04",
-                "centos8_stream",
-                "centos9_stream",
-		"alma8",
-		"alma9"
-            ]
-        }
-    ]
+  "base_path": "/home/imgbuild/log",
+  "environments": [
+    {
+      "name": "e",
+      "images": [
+        "ubuntu-18.04",
+        "ubuntu-20.04",
+        "ubuntu-22.04",
+        "ubuntu-24.04",
+        "centos9_stream",
+        "alma8",
+        "alma9"
+      ]
+    }
+  ]
 }

--- a/check_image_building/check_image_building_epouta_production.json
+++ b/check_image_building/check_image_building_epouta_production.json
@@ -1,0 +1,18 @@
+{
+    "base_path" : "/home/imgbuild/log",
+    "environments" : [
+        {
+            "name" : "e",
+            "images" : [
+                "ubuntu-18.04",
+                "ubuntu-20.04",
+                "ubuntu-22.04",
+                "ubuntu-24.04",
+                "centos8_stream",
+                "centos9_stream",
+		"alma8",
+		"alma9"
+            ]
+        }
+    ]
+}

--- a/scripts/crontab
+++ b/scripts/crontab
@@ -9,9 +9,9 @@ SHELL=/bin/bash
 
 ######## cPouta production
 #  m  h  dom  mon  dow   command
-   0  0  1,16 *    *     source $HOME/bin/openrc_cpouta_prod_v3.sh; $HOME/diskimage-builder-scripts.cpouta/scripts/image_create_centos7.sh >> $HOME/log/c/centos7.log 2>&1
+#  0  0  1,16 *    *     source $HOME/bin/openrc_cpouta_prod_v3.sh; $HOME/diskimage-builder-scripts.cpouta/scripts/image_create_centos7.sh >> $HOME/log/c/centos7.log 2>&1
 # 15  0  1,16 *    *     Reserved for CentOS-7 building
-  30  0  1,16 *    *     source $HOME/bin/openrc_cpouta_prod_v3.sh; $HOME/diskimage-builder-scripts.cpouta/scripts/image_create_centos7-cuda.sh >> $HOME/log/c/centos7-cuda.log 2>&1
+# 30  0  1,16 *    *     source $HOME/bin/openrc_cpouta_prod_v3.sh; $HOME/diskimage-builder-scripts.cpouta/scripts/image_create_centos7-cuda.sh >> $HOME/log/c/centos7-cuda.log 2>&1
 # 45  0  1,16 *    *     Reserved for CentOS-7-cuda building
 #  0  1  1,16 *    *     Reserved for CentOS-7-cuda building
 # 15  1  1,16 *    *     Reserved for CentOS-7-cuda building
@@ -28,9 +28,9 @@ SHELL=/bin/bash
 
 ######## ePouta production
 #  m  h  dom  mon  dow   command
-   0  4  2,17 *    *     source $HOME/bin/openrc_epouta_prod_v3.sh; $HOME/diskimage-builder-scripts.epouta/scripts/image_create_centos7.sh >> $HOME/log/e/centos7.log 2>&1
+#  0  4  2,17 *    *     source $HOME/bin/openrc_epouta_prod_v3.sh; $HOME/diskimage-builder-scripts.epouta/scripts/image_create_centos7.sh >> $HOME/log/e/centos7.log 2>&1
 # 15  4  2,17 *    *     Reserved for CentOS-7 building
-  30  4  2,17 *    *     source $HOME/bin/openrc_epouta_prod_v3.sh; $HOME/diskimage-builder-scripts.epouta/scripts/image_create_centos7-cuda.sh >> $HOME/log/e/centos7-cuda.log 2>&1
+# 30  4  2,17 *    *     source $HOME/bin/openrc_epouta_prod_v3.sh; $HOME/diskimage-builder-scripts.epouta/scripts/image_create_centos7-cuda.sh >> $HOME/log/e/centos7-cuda.log 2>&1
 # 45  4  2,17 *    *     Reserved for CentOS-7-cuda building
 #  0  5  2,17 *    *     Reserved for CentOS-7-cuda building
 # 15  5  2,17 *    *     Reserved for CentOS-7-cuda building
@@ -85,9 +85,9 @@ SHELL=/bin/bash
 
 ######## cPouta development
 #  m  h  dom  mon  dow   command
-   0 16  *    *    *     source $HOME/bin/openrc_cpouta_devel_v3.sh; $HOME/diskimage-builder-scripts.cpouta-devel/scripts/image_create_centos7.sh >> $HOME/log/c-devel/centos7.log 2>&1
+#  0 16  *    *    *     source $HOME/bin/openrc_cpouta_devel_v3.sh; $HOME/diskimage-builder-scripts.cpouta-devel/scripts/image_create_centos7.sh >> $HOME/log/c-devel/centos7.log 2>&1
 # 15 16  *    *    *     Reserved for CentOS-7 building
-  30 16  *    *    *     source $HOME/bin/openrc_cpouta_devel_v3.sh; $HOME/diskimage-builder-scripts.cpouta-devel/scripts/image_create_centos7-cuda.sh >> $HOME/log/c-devel/centos7-cuda.log 2>&1
+# 30 16  *    *    *     source $HOME/bin/openrc_cpouta_devel_v3.sh; $HOME/diskimage-builder-scripts.cpouta-devel/scripts/image_create_centos7-cuda.sh >> $HOME/log/c-devel/centos7-cuda.log 2>&1
 # 45 16  *    *    *     Reserved for CentOS-7-cuda building
 #  0 17  *    *    *     Reserved for CentOS-7-cuda building
 # 15 17  *    *    *     Reserved for CentOS-7-cuda building
@@ -104,9 +104,9 @@ SHELL=/bin/bash
 
 ######## ePouta development
 #  m  h  dom  mon  dow   command
-   0 20  *    *    *     source $HOME/bin/openrc_epouta_devel_v3.sh; $HOME/diskimage-builder-scripts.epouta-devel/scripts/image_create_centos7.sh >> $HOME/log/e-devel/centos7.log 2>&1
+#  0 20  *    *    *     source $HOME/bin/openrc_epouta_devel_v3.sh; $HOME/diskimage-builder-scripts.epouta-devel/scripts/image_create_centos7.sh >> $HOME/log/e-devel/centos7.log 2>&1
 # 15 20  *    *    *     Reserved for CentOS-7 building
-  30 20  *    *    *     source $HOME/bin/openrc_epouta_devel_v3.sh; $HOME/diskimage-builder-scripts.epouta-devel/scripts/image_create_centos7-cuda.sh >> $HOME/log/e-devel/centos7-cuda.log 2>&1
+# 30 20  *    *    *     source $HOME/bin/openrc_epouta_devel_v3.sh; $HOME/diskimage-builder-scripts.epouta-devel/scripts/image_create_centos7-cuda.sh >> $HOME/log/e-devel/centos7-cuda.log 2>&1
 # 45 20  *    *    *     Reserved for CentOS-7-cuda building
 #  0 21  *    *    *     Reserved for CentOS-7-cuda building
 # 15 21  *    *    *     Reserved for CentOS-7-cuda building

--- a/scripts/crontab
+++ b/scripts/crontab
@@ -9,12 +9,12 @@ SHELL=/bin/bash
 
 ######## cPouta production
 #  m  h  dom  mon  dow   command
-#  0  0  1,16 *    *     source $HOME/bin/openrc_cpouta_prod_v3.sh; $HOME/diskimage-builder-scripts.cpouta/scripts/image_create_centos7.sh >> $HOME/log/c/centos7.log 2>&1
-# 15  0  1,16 *    *     Reserved for CentOS-7 building
-# 30  0  1,16 *    *     source $HOME/bin/openrc_cpouta_prod_v3.sh; $HOME/diskimage-builder-scripts.cpouta/scripts/image_create_centos7-cuda.sh >> $HOME/log/c/centos7-cuda.log 2>&1
-# 45  0  1,16 *    *     Reserved for CentOS-7-cuda building
-#  0  1  1,16 *    *     Reserved for CentOS-7-cuda building
-# 15  1  1,16 *    *     Reserved for CentOS-7-cuda building
+#  0  0  1,16 *    *     Free slot
+# 15  0  1,16 *    *     Free slot
+# 30  0  1,16 *    *     Free slot
+# 45  0  1,16 *    *     Free slot
+#  0  1  1,16 *    *     Free slot
+# 15  1  1,16 *    *     Free slot
   30  1  1,16 *    *     source $HOME/bin/openrc_cpouta_prod_v3.sh; $HOME/diskimage-builder-scripts.cpouta/scripts/image_create_ubuntu-18.04.sh >> $HOME/log/c/ubuntu-18.04.log 2>&1
   45  1  1,16 *    *     source $HOME/bin/openrc_cpouta_prod_v3.sh; $HOME/diskimage-builder-scripts.cpouta/scripts/image_create_ubuntu-20.04.sh >> $HOME/log/c/ubuntu-20.04.log 2>&1
    0  2  1,16 *    *     source $HOME/bin/openrc_cpouta_prod_v3.sh; $HOME/diskimage-builder-scripts.cpouta/scripts/image_create_ubuntu-22.04.sh >> $HOME/log/c/ubuntu-22.04.log 2>&1
@@ -28,12 +28,12 @@ SHELL=/bin/bash
 
 ######## ePouta production
 #  m  h  dom  mon  dow   command
-#  0  4  2,17 *    *     source $HOME/bin/openrc_epouta_prod_v3.sh; $HOME/diskimage-builder-scripts.epouta/scripts/image_create_centos7.sh >> $HOME/log/e/centos7.log 2>&1
-# 15  4  2,17 *    *     Reserved for CentOS-7 building
-# 30  4  2,17 *    *     source $HOME/bin/openrc_epouta_prod_v3.sh; $HOME/diskimage-builder-scripts.epouta/scripts/image_create_centos7-cuda.sh >> $HOME/log/e/centos7-cuda.log 2>&1
-# 45  4  2,17 *    *     Reserved for CentOS-7-cuda building
-#  0  5  2,17 *    *     Reserved for CentOS-7-cuda building
-# 15  5  2,17 *    *     Reserved for CentOS-7-cuda building
+#  0  4  2,17 *    *     Free slot
+# 15  4  2,17 *    *     Free slot
+# 30  4  2,17 *    *     Free slot
+# 45  4  2,17 *    *     Free slot
+#  0  5  2,17 *    *     Free slot
+# 15  5  2,17 *    *     Free slot
   30  5  2,17 *    *     source $HOME/bin/openrc_epouta_prod_v3.sh; $HOME/diskimage-builder-scripts.epouta/scripts/image_create_ubuntu-18.04.sh >> $HOME/log/e/ubuntu-18.04.log 2>&1
   45  5  2,17 *    *     source $HOME/bin/openrc_epouta_prod_v3.sh; $HOME/diskimage-builder-scripts.epouta/scripts/image_create_ubuntu-20.04.sh >> $HOME/log/e/ubuntu-20.04.log 2>&1
    0  6  2,17 *    *     source $HOME/bin/openrc_epouta_prod_v3.sh; $HOME/diskimage-builder-scripts.epouta/scripts/image_create_ubuntu-22.04.sh >> $HOME/log/e/ubuntu-22.04.log 2>&1
@@ -85,12 +85,12 @@ SHELL=/bin/bash
 
 ######## cPouta development
 #  m  h  dom  mon  dow   command
-#  0 16  *    *    *     source $HOME/bin/openrc_cpouta_devel_v3.sh; $HOME/diskimage-builder-scripts.cpouta-devel/scripts/image_create_centos7.sh >> $HOME/log/c-devel/centos7.log 2>&1
-# 15 16  *    *    *     Reserved for CentOS-7 building
-# 30 16  *    *    *     source $HOME/bin/openrc_cpouta_devel_v3.sh; $HOME/diskimage-builder-scripts.cpouta-devel/scripts/image_create_centos7-cuda.sh >> $HOME/log/c-devel/centos7-cuda.log 2>&1
-# 45 16  *    *    *     Reserved for CentOS-7-cuda building
-#  0 17  *    *    *     Reserved for CentOS-7-cuda building
-# 15 17  *    *    *     Reserved for CentOS-7-cuda building
+#  0 16  *    *    *     Free slot
+# 15 16  *    *    *     Free slot
+# 30 16  *    *    *     Free slot
+# 45 16  *    *    *     Free slot
+#  0 17  *    *    *     Free slot
+# 15 17  *    *    *     Free slot
   30 17  *    *    *     source $HOME/bin/openrc_cpouta_devel_v3.sh; $HOME/diskimage-builder-scripts.cpouta-devel/scripts/image_create_ubuntu-18.04.sh >> $HOME/log/c-devel/ubuntu-18.04.log 2>&1
   45 17  *    *    *     source $HOME/bin/openrc_cpouta_devel_v3.sh; $HOME/diskimage-builder-scripts.cpouta-devel/scripts/image_create_ubuntu-20.04.sh >> $HOME/log/c-devel/ubuntu-20.04.log 2>&1
    0 18  *    *    *     source $HOME/bin/openrc_cpouta_devel_v3.sh; $HOME/diskimage-builder-scripts.cpouta-devel/scripts/image_create_ubuntu-22.04.sh >> $HOME/log/c-devel/ubuntu-22.04.log 2>&1
@@ -104,12 +104,12 @@ SHELL=/bin/bash
 
 ######## ePouta development
 #  m  h  dom  mon  dow   command
-#  0 20  *    *    *     source $HOME/bin/openrc_epouta_devel_v3.sh; $HOME/diskimage-builder-scripts.epouta-devel/scripts/image_create_centos7.sh >> $HOME/log/e-devel/centos7.log 2>&1
-# 15 20  *    *    *     Reserved for CentOS-7 building
-# 30 20  *    *    *     source $HOME/bin/openrc_epouta_devel_v3.sh; $HOME/diskimage-builder-scripts.epouta-devel/scripts/image_create_centos7-cuda.sh >> $HOME/log/e-devel/centos7-cuda.log 2>&1
-# 45 20  *    *    *     Reserved for CentOS-7-cuda building
-#  0 21  *    *    *     Reserved for CentOS-7-cuda building
-# 15 21  *    *    *     Reserved for CentOS-7-cuda building
+#  0 20  *    *    *     Free slot
+# 15 20  *    *    *     Free slot
+# 30 20  *    *    *     Free slot
+# 45 20  *    *    *     Free slot
+#  0 21  *    *    *     Free slot
+# 15 21  *    *    *     Free slot
   30 21  *    *    *     source $HOME/bin/openrc_epouta_devel_v3.sh; $HOME/diskimage-builder-scripts.epouta-devel/scripts/image_create_ubuntu-18.04.sh >> $HOME/log/e-devel/ubuntu-18.04.log 2>&1
   45 21  *    *    *     source $HOME/bin/openrc_epouta_devel_v3.sh; $HOME/diskimage-builder-scripts.epouta-devel/scripts/image_create_ubuntu-20.04.sh >> $HOME/log/e-devel/ubuntu-20.04.log 2>&1
    0 22  *    *    *     source $HOME/bin/openrc_epouta_devel_v3.sh; $HOME/diskimage-builder-scripts.epouta-devel/scripts/image_create_ubuntu-22.04.sh >> $HOME/log/e-devel/ubuntu-22.04.log 2>&1
@@ -120,4 +120,3 @@ SHELL=/bin/bash
   15 23  *    *    *     source $HOME/bin/openrc_epouta_devel_v3.sh; $HOME/diskimage-builder-scripts.epouta-devel/scripts/image_create_ubuntu-24.04.sh >> $HOME/log/e-devel/ubuntu-24.04.log 2>&1
 # 30 23  *    *    *     Free slot
 # 45 23  *    *    *     Free slot
-

--- a/scripts/crontab
+++ b/scripts/crontab
@@ -18,7 +18,7 @@ SHELL=/bin/bash
   30  1  1,16 *    *     source $HOME/bin/openrc_cpouta_prod_v3.sh; $HOME/diskimage-builder-scripts.cpouta/scripts/image_create_ubuntu-18.04.sh >> $HOME/log/c/ubuntu-18.04.log 2>&1
   45  1  1,16 *    *     source $HOME/bin/openrc_cpouta_prod_v3.sh; $HOME/diskimage-builder-scripts.cpouta/scripts/image_create_ubuntu-20.04.sh >> $HOME/log/c/ubuntu-20.04.log 2>&1
    0  2  1,16 *    *     source $HOME/bin/openrc_cpouta_prod_v3.sh; $HOME/diskimage-builder-scripts.cpouta/scripts/image_create_ubuntu-22.04.sh >> $HOME/log/c/ubuntu-22.04.log 2>&1
-  15  2  1,16 *    *     source $HOME/bin/openrc_cpouta_prod_v3.sh; $HOME/diskimage-builder-scripts.cpouta/scripts/image_create_centos8_stream.sh >> $HOME/log/c/centos8_stream.log 2>&1
+# 15  2  1,16 *    *     Free slot
   30  2  1,16 *    *     source $HOME/bin/openrc_cpouta_prod_v3.sh; $HOME/diskimage-builder-scripts.cpouta/scripts/image_create_centos9_stream.sh >> $HOME/log/c/centos9_stream.log 2>&1
   45  2  1,16 *    *     source $HOME/bin/openrc_cpouta_prod_v3.sh; $HOME/diskimage-builder-scripts.cpouta/scripts/image_create_alma8.sh >> $HOME/log/c/alma8.log 2>&1
    0  3  1,16 *    *     source $HOME/bin/openrc_cpouta_prod_v3.sh; $HOME/diskimage-builder-scripts.cpouta/scripts/image_create_alma9.sh >> $HOME/log/c/alma9.log 2>&1
@@ -37,7 +37,7 @@ SHELL=/bin/bash
   30  5  2,17 *    *     source $HOME/bin/openrc_epouta_prod_v3.sh; $HOME/diskimage-builder-scripts.epouta/scripts/image_create_ubuntu-18.04.sh >> $HOME/log/e/ubuntu-18.04.log 2>&1
   45  5  2,17 *    *     source $HOME/bin/openrc_epouta_prod_v3.sh; $HOME/diskimage-builder-scripts.epouta/scripts/image_create_ubuntu-20.04.sh >> $HOME/log/e/ubuntu-20.04.log 2>&1
    0  6  2,17 *    *     source $HOME/bin/openrc_epouta_prod_v3.sh; $HOME/diskimage-builder-scripts.epouta/scripts/image_create_ubuntu-22.04.sh >> $HOME/log/e/ubuntu-22.04.log 2>&1
-  15  6  2,17 *    *     source $HOME/bin/openrc_epouta_prod_v3.sh; $HOME/diskimage-builder-scripts.epouta/scripts/image_create_centos8_stream.sh >> $HOME/log/e/centos8_stream.log 2>&1
+# 15  6  2,17 *    *     Free slot
   30  6  2,17 *    *     source $HOME/bin/openrc_epouta_prod_v3.sh; $HOME/diskimage-builder-scripts.epouta/scripts/image_create_centos9_stream.sh >> $HOME/log/e/centos9_stream.log 2>&1
   45  6  2,17 *    *     source $HOME/bin/openrc_epouta_prod_v3.sh; $HOME/diskimage-builder-scripts.epouta/scripts/image_create_alma8.sh >> $HOME/log/e/alma8.log 2>&1
    0  7  2,17 *    *     source $HOME/bin/openrc_epouta_prod_v3.sh; $HOME/diskimage-builder-scripts.epouta/scripts/image_create_alma9.sh >> $HOME/log/e/alma9.log 2>&1
@@ -94,7 +94,7 @@ SHELL=/bin/bash
   30 17  *    *    *     source $HOME/bin/openrc_cpouta_devel_v3.sh; $HOME/diskimage-builder-scripts.cpouta-devel/scripts/image_create_ubuntu-18.04.sh >> $HOME/log/c-devel/ubuntu-18.04.log 2>&1
   45 17  *    *    *     source $HOME/bin/openrc_cpouta_devel_v3.sh; $HOME/diskimage-builder-scripts.cpouta-devel/scripts/image_create_ubuntu-20.04.sh >> $HOME/log/c-devel/ubuntu-20.04.log 2>&1
    0 18  *    *    *     source $HOME/bin/openrc_cpouta_devel_v3.sh; $HOME/diskimage-builder-scripts.cpouta-devel/scripts/image_create_ubuntu-22.04.sh >> $HOME/log/c-devel/ubuntu-22.04.log 2>&1
-  15 18  *    *    *     source $HOME/bin/openrc_cpouta_devel_v3.sh; $HOME/diskimage-builder-scripts.cpouta-devel/scripts/image_create_centos8_stream.sh >> $HOME/log/c-devel/centos8_stream.log 2>&1
+# 15 18  *    *    *     Free slot
   30 18  *    *    *     source $HOME/bin/openrc_cpouta_devel_v3.sh; $HOME/diskimage-builder-scripts.cpouta-devel/scripts/image_create_centos9_stream.sh >> $HOME/log/c-devel/centos9_stream.log 2>&1
   45 18  *    *    *     source $HOME/bin/openrc_cpouta_devel_v3.sh; $HOME/diskimage-builder-scripts.cpouta-devel/scripts/image_create_alma8.sh >> $HOME/log/c-devel/alma8.log 2>&1
    0 19  *    *    *     source $HOME/bin/openrc_cpouta_devel_v3.sh; $HOME/diskimage-builder-scripts.cpouta-devel/scripts/image_create_alma9.sh >> $HOME/log/c-devel/alma9.log 2>&1
@@ -113,7 +113,7 @@ SHELL=/bin/bash
   30 21  *    *    *     source $HOME/bin/openrc_epouta_devel_v3.sh; $HOME/diskimage-builder-scripts.epouta-devel/scripts/image_create_ubuntu-18.04.sh >> $HOME/log/e-devel/ubuntu-18.04.log 2>&1
   45 21  *    *    *     source $HOME/bin/openrc_epouta_devel_v3.sh; $HOME/diskimage-builder-scripts.epouta-devel/scripts/image_create_ubuntu-20.04.sh >> $HOME/log/e-devel/ubuntu-20.04.log 2>&1
    0 22  *    *    *     source $HOME/bin/openrc_epouta_devel_v3.sh; $HOME/diskimage-builder-scripts.epouta-devel/scripts/image_create_ubuntu-22.04.sh >> $HOME/log/e-devel/ubuntu-22.04.log 2>&1
-  15 22  *    *    *     source $HOME/bin/openrc_epouta_devel_v3.sh; $HOME/diskimage-builder-scripts.epouta-devel/scripts/image_create_centos8_stream.sh >> $HOME/log/e-devel/centos8_stream.log 2>&1
+# 15 22  *    *    *     Free slot
   30 22  *    *    *     source $HOME/bin/openrc_epouta_devel_v3.sh; $HOME/diskimage-builder-scripts.epouta-devel/scripts/image_create_centos9_stream.sh >> $HOME/log/e-devel/centos9_stream.log 2>&1
   45 22  *    *    *     source $HOME/bin/openrc_epouta_devel_v3.sh; $HOME/diskimage-builder-scripts.epouta-devel/scripts/image_create_alma8.sh >> $HOME/log/e-devel/alma8.log 2>&1
    0 23  *    *    *     source $HOME/bin/openrc_epouta_devel_v3.sh; $HOME/diskimage-builder-scripts.epouta-devel/scripts/image_create_alma9.sh >> $HOME/log/e-devel/alma9.log 2>&1


### PR DESCRIPTION
CentOS7 is out of life and therefore, we are not making CentOS7 and Centos7-Cuda image build anymore.

CCCP-4561